### PR TITLE
Added bnd plugin for OSGi metadata generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id "maven-publish"
     id "com.jfrog.bintray" version "1.8.4"
     id 'com.adarshr.test-logger' version '1.6.0'
+    id "biz.aQute.bnd.builder" version "5.2.0"
 }
 
 compileJava.options.encoding = 'UTF-8'
@@ -32,6 +33,10 @@ sourceSets {
         srcDirs = ['src/example/java', 'src/test/java']
       }
    }
+}
+
+jar {
+  bnd('-exportcontents': 'com.zakgof.actr')
 }
  
 task sourcesJar(type: Jar, dependsOn: classes) {


### PR DESCRIPTION
I've added the bnd plugin to the build file so that your actr framework (awesome idea btw) in an OSGi environment. This plugin just generates more metadata into the MANIFEST.MF file, so nothing else in your code is changed :)